### PR TITLE
Update NHS COVID Pass home screen panel link text and update panel-link CSS

### DIFF
--- a/app/assets/sass/components/_panel-link.scss
+++ b/app/assets/sass/components/_panel-link.scss
@@ -2,9 +2,7 @@
 // COMPONENTS / #PANEL-LINK
 // ==========================================================================
 
-
 .panel-link {
-  border-top: 1px $color_nhsuk-grey-4 solid;
   font-size: 1em;
   list-style: none;
   margin-bottom: 1em;
@@ -16,11 +14,15 @@
 
   .panel-link__item {
     border-bottom: 1px $color_nhsuk-grey-4 solid;
-    margin-bottom: .2em;
+    border-top: 1px $color_nhsuk-grey-4 solid;
+    margin-bottom: 4px;
     padding: 0;
   }
 
   .panel-link__link {
+    @media (max-width: 640px) {
+      padding: 8px 40px 8px 16px;
+    }
     background-color: $color_nhsuk-white;
     background-image: url(../images/icon_arrow_left.svg);
     background-position: right 1em center;
@@ -30,13 +32,34 @@
     padding: 16px 40px 16px 16px;
     text-decoration: none;
 
+
+    &:focus {
+      background-color: #ffffff;
+      box-shadow: none;
+      color: #212b32;
+      outline: 4px solid transparent;
+      text-decoration: none;
+    }
+
+    &:focus h2 {
+      background-color: #ffeb3b!important;
+    box-shadow: 0 -2px #ffeb3b,0 4px #212b32!important;
+    color: #212b32!important;
+    outline: 4px solid transparent!important;
+    text-decoration: none!important;
+    outline-color: transparent!important;
+    border-bottom: 4px #212b32;
+    width: max-content;
+    max-width: 100%!important;
+    }
+
     &:hover {
-      box-shadow: 0 0 0 4px $color_nhsuk-yellow;
-      color: $color_nhsuk-blue;
+
     }
 
     &:hover h2 {
-      text-decoration: none;
+      color: #7c2855;
+      text-decoration: underline;
     }
 
     &:visited {
@@ -52,6 +75,7 @@
     .panel-link__content {
       color: $color_nhsuk-black;
       margin-bottom: 0;
+      padding: 4px 0px 4px 0px;
     }
 
   }

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -70,7 +70,7 @@
           <li class="panel-link__item">
             <a class="panel-link__link" href="#">
               <h2 class="panel-link__heading nhsuk-heading-s">Get your NHS COVID Pass</h2>
-              <p class="panel-link__content">View and share your COVID Pass for events in England and travel abroad</p>
+              <p class="panel-link__content">View and share your COVID Pass for places in England that have chosen to use this service and for travel abroad</p>
             </a>
           </li>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3099,7 +3099,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3117,11 +3118,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3134,15 +3137,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3245,7 +3251,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3255,6 +3262,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3267,17 +3275,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3294,6 +3305,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3366,7 +3378,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3376,6 +3389,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3451,7 +3465,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3481,6 +3496,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3498,6 +3514,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3536,11 +3553,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Changes made in this pull request:

1. Updated the panel link text for the NHS COVID Pass to match the live NHS App
2. Updated CSS for the panel-link to match the live NHS App for both desktop and mobile screens, as well as updating the hover and focus states